### PR TITLE
fix(whitelist): add dl.k8s.io to proxy whitelist

### DIFF
--- a/configs/web_whitelist
+++ b/configs/web_whitelist
@@ -32,7 +32,6 @@ cri-app02.bsd.uchicago.edu
 csc.mcs.sdsmt.edu
 decider.oicrsofteng.org
 dl.bintray.com
-dl.k8s.io
 dmas.berkeley.edu
 download.java.net
 download.oracle.com

--- a/configs/web_whitelist
+++ b/configs/web_whitelist
@@ -32,6 +32,7 @@ cri-app02.bsd.uchicago.edu
 csc.mcs.sdsmt.edu
 decider.oicrsofteng.org
 dl.bintray.com
+dl.k8s.io
 dmas.berkeley.edu
 download.java.net
 download.oracle.com

--- a/configs/web_wildcard_whitelist
+++ b/configs/web_wildcard_whitelist
@@ -19,6 +19,7 @@
 .gitlab.com
 .hashicorp.com
 .jenkins-ci.org
+.k8s.io
 .letsencrypt.org
 .maven.org
 .metacpan.org


### PR DESCRIPTION
added dl.k8s.io to proxy whitelist - k8s is not posting downloads to this domain:

https://github.com/kubernetes/kubernetes/issues/33726
https://github.com/kubernetes/kubernetes/releases
